### PR TITLE
Bugfixes

### DIFF
--- a/install_kaldi.sh
+++ b/install_kaldi.sh
@@ -23,11 +23,11 @@ touch "python/.use_default_python"
 
 ./extras/check_dependencies.sh
 
-make -j4
+make -j$(nproc)
 
 cd ../src
 ./configure --help
 ./configure --shared --static-math=yes
-make clean -j && make depend -j 16 && make -j 16
+make clean -j$(nproc) && make depend -j$(nproc) && make -j$(nproc)
 
 echo "Done installing Kaldi."

--- a/install_kaldi.sh
+++ b/install_kaldi.sh
@@ -26,7 +26,6 @@ touch "python/.use_default_python"
 make -j$(nproc)
 
 cd ../src
-./configure --help
 ./configure --shared --static-math=yes
 make clean -j$(nproc) && make depend -j$(nproc) && make -j$(nproc)
 

--- a/install_kaldi_intel.sh
+++ b/install_kaldi_intel.sh
@@ -23,11 +23,11 @@ touch "python/.use_default_python"
 
 ./extras/check_dependencies.sh
 
-make -j4
+make -j$(nproc)
 
 cd ../src
 ./configure --help
 ./configure --shared --cudatk-dir=/usr/local/cuda/ --mathlib=MKL --mkl-root=/opt/intel/mkl/ --use-cuda=no --static-math=yes
-make clean -j && make depend -j 16 && make -j 16
+make clean -j$(nproc) && make depend -j$(nproc) && make -j$(nproc)
 
 echo "Done installing Kaldi."

--- a/install_kaldi_intel.sh
+++ b/install_kaldi_intel.sh
@@ -26,7 +26,6 @@ touch "python/.use_default_python"
 make -j$(nproc)
 
 cd ../src
-./configure --help
 ./configure --shared --cudatk-dir=/usr/local/cuda/ --mathlib=MKL --mkl-root=/opt/intel/mkl/ --use-cuda=no --static-math=yes
 make clean -j$(nproc) && make depend -j$(nproc) && make -j$(nproc)
 

--- a/subtitle2go.py
+++ b/subtitle2go.py
@@ -334,8 +334,7 @@ if __name__ == "__main__":
                                                           "Higher values make it more likely to always split at commas.",
                         type=float, default=0.5)
 
-    if redis_enabled:
-        parser.add_argument("--with-redis-updates", help="Update a redis instance about the current progress.",
+    parser.add_argument("--with-redis-updates", help="Update a redis instance about the current progress.",
                         action='store_true', default=False)
 
     # positional argument, without (- and --)


### PR DESCRIPTION
I fixed some bugs:

1. `subtitle2go.py` fails, if redis is not used/installed. This is caused by adding `with_redis_updates` to the argument parser only, if redis is configured
2. Added `nproc` to `make` calls in `install_kaldi*.sh` to improve compile time on "heavy" machines
3. Remove unnecessary "help-calls" in `install_kaldi*.sh`